### PR TITLE
ドキュメント: READMEに参考リソースを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ AI Enabling（AI支援開発の実現）とは、AIツール（Claude Code、Cur
 - **RSS解析**: rss-parser
 - **データソース**: Zenn RSS feeds
 
+## 参考リソース
+
+- [MCP公式ドキュメント](https://modelcontextprotocol.io/)
+- [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
+- [Zenn RSS仕様](https://zenn.dev/zenn/articles/zenn-feed-rss)
+
 ## ライセンス
 
 MIT


### PR DESCRIPTION
## 概要
READMEに参考リソースセクションを追加しました。

## 変更内容
- MCP公式ドキュメントへのリンク追加
- MCP TypeScript SDKへのリンク追加
- Zenn RSS仕様へのリンク追加

## 理由
新規ユーザーが関連ドキュメントを簡単に見つけられるようにするため。